### PR TITLE
Init: Fix pip package installation error

### DIFF
--- a/ansible/roles/aws_instance/tasks/main.yml
+++ b/ansible/roles/aws_instance/tasks/main.yml
@@ -7,18 +7,34 @@
   become: true
   vars:
     packages:
-    - git
-    - python3-devel
+    - git-core
     - jq
     - terraform
     - lorax
     - anaconda-tui
     - subscription-manager
 
+- name: Install Python development tools
+  ansible.builtin.dnf:
+    name:
+      - python39-devel
+      - python39-wheel-wheel
+      - python39-wheel
+      - python39-setuptools-wheel
+      - python39-setuptools
+  become: yes
+  become_user: root
+
 - name: Installing testinfra
   pip:
-    name: ['pytest', 'pyinfra', 'testinfra', 'boto3', 'markdown_table']
-    executable: pip3
+    name:
+      - pytest-testinfra
+      - paramiko
+      - boto3
+      - markdown-table
+    executable: pip3.9
+    extra_args: --no-cache-dir --upgrade
+    state: present
   become: yes
   become_user: root
 


### PR DESCRIPTION
Fix pip package installation and some enhancements:

* Install the git-core package instead of the git
* Create an Ansible task to install Python 3.9 development packages
* PIP: Use the actual name of the Testinfra package: pytest-testinfra
* PIP: Add paramiko for Testinfra's SSH backend
* PIP: Make sure the latest version of the packages installed

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>