### PR TITLE
Cloud image builds - AlmaLinux 9 updates

### DIFF
--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -112,7 +112,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-dev-testing-bala',
+                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
                             color: 'good',
                             message: "The build for Almalinux ${params.OS_MAJOR_VER}, job ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -172,12 +172,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log, *.md, *.csv, wiki/*.csv, wiki/*.md'
       }
       success {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -195,7 +195,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -42,6 +42,7 @@ pipeline {
       AWS_SECRET_ACCESS_KEY = credentials('jenkins-aws-secret-access-key')
       SSH_KEY_FILE = credentials('jenkins-aclib-ssh-private-key')
       GITHUB_TOKEN = credentials('github_token')
+      OS_MAJOR_VER = "${params.OS_MAJOR_VER}"
   }
   options {
     // This is required if you want to clean before build
@@ -60,7 +61,6 @@ pipeline {
       stage('Create AWS instance for AWS AMI') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performCreateStages(arch)
@@ -74,7 +74,6 @@ pipeline {
             stage('Build stage 1') {
                 steps {
                       script {
-                          env.OS_MAJOR_VER = params.OS_MAJOR_VER
                           def jobs = [:]
                           for (arch in params.ARCH.replace('"', '').split(',')) {
                               jobs[arch] = performBuildStages(arch)
@@ -86,7 +85,6 @@ pipeline {
               stage('Build AWS AMI stage 2') {
                   steps {
                       script {
-                          env.OS_MAJOR_VER = params.OS_MAJOR_VER
                           def jobs = [:]
                           for (arch in params.ARCH.replace('"', '').split(',')) {
                               if (arch == 'x86_64') {
@@ -102,7 +100,6 @@ pipeline {
       stage('Test AWS AMI') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performTestStages(arch)
@@ -113,8 +110,8 @@ pipeline {
           post {
               success {
                   slackSend channel: '#albs-jenkins-notifications-dev-qa',
-                            color: 'good',
-                            message: "The build for Almalinux ${params.OS_MAJOR_VER}, job ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
+                    color: 'good',
+                    message: "The build for Almalinux ${OS_MAJOR_VER}, job ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
               }
           }
       }
@@ -122,7 +119,6 @@ pipeline {
         steps {
               timeout(time:2, unit:'DAYS') {
                   script {
-                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'AMI successfully scanned and ready for release ?', ok: 'Starting publishing!',
@@ -153,7 +149,6 @@ pipeline {
           }
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)
@@ -182,7 +177,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)
@@ -200,7 +194,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)

--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -109,7 +109,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
+                  slackSend channel: '#albs-jenkins-action-required',
                     color: 'good',
                     message: "The build for Almalinux ${OS_MAJOR_VER}, job ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -167,12 +167,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log, *.md, *.csv, wiki/*.csv, wiki/*.md'
       }
       success {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -189,7 +189,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -44,7 +44,7 @@ pipeline {
       GITHUB_TOKEN = credentials('github_token')
   }
   options {
-        // This is required if you want to clean before build
+    // This is required if you want to clean before build
     skipDefaultCheckout(true)
   }
   stages {

--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -31,6 +31,7 @@ def performPublishStages(String arch) {
 pipeline {
   agent any
   parameters {
+      choice(name: 'OS_MAJOR_VER', choices: ['8', '9'], description: 'AlmaLinux Major Version')
       choice(name: 'IMAGE', choices: ['AWS AMI', 'Vagrant Box', 'GenericCloud', 'OpenNebula'], description: 'Cloud image to update: build, test, release')
       extendedChoice(defaultValue: 'x86_64', description: 'Architecture to build', descriptionPropertyValue: '', multiSelectDelimiter: ',', name: 'ARCH', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_MULTI_SELECT', value: 'x86_64, aarch64', visibleItemCount: 2)
       string(name: 'BUCKET', defaultValue: 'alcib', description: 'S3 BUCKET NAME')
@@ -47,6 +48,7 @@ pipeline {
       stage('Create AWS instance for AWS AMI') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performCreateStages(arch)
@@ -60,6 +62,7 @@ pipeline {
             stage('Build stage 1') {
                 steps {
                       script {
+                          env.OS_MAJOR_VER = params.OS_MAJOR_VER
                           def jobs = [:]
                           for (arch in params.ARCH.replace('"', '').split(',')) {
                               jobs[arch] = performBuildStages(arch)
@@ -71,6 +74,7 @@ pipeline {
               stage('Build AWS AMI stage 2') {
                   steps {
                       script {
+                          env.OS_MAJOR_VER = params.OS_MAJOR_VER
                           def jobs = [:]
                           for (arch in params.ARCH.replace('"', '').split(',')) {
                               if (arch == 'x86_64') {
@@ -86,6 +90,7 @@ pipeline {
       stage('Test AWS AMI') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performTestStages(arch)
@@ -95,9 +100,9 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#test-auto-vagrant',
+                  slackSend channel: '#albs-dev-testing-bala',
                             color: 'good',
-                            message: "The build ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
+                            message: "The build for Almalinux ${params.OS_MAJOR_VER}, job ${currentBuild.fullDisplayName} ready to be released as new AWS AMIs, please, approve: ${currentBuild.absoluteUrl}"
               }
           }
       }
@@ -105,6 +110,7 @@ pipeline {
         steps {
               timeout(time:2, unit:'DAYS') {
                   script {
+                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'AMI successfully scanned and ready for release ?', ok: 'Starting publishing!',
@@ -135,6 +141,7 @@ pipeline {
           }
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)
@@ -153,16 +160,17 @@ pipeline {
           archiveArtifacts artifacts: '*.log, *.md, *.csv, wiki/*.csv, wiki/*.md'
       }
       success {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)
@@ -175,11 +183,12 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       jobs[arch] = performDestroyStages(arch)

--- a/JenkinsfileAWS
+++ b/JenkinsfileAWS
@@ -43,8 +43,20 @@ pipeline {
       SSH_KEY_FILE = credentials('jenkins-aclib-ssh-private-key')
       GITHUB_TOKEN = credentials('github_token')
   }
-
+  options {
+        // This is required if you want to clean before build
+    skipDefaultCheckout(true)
+  }
   stages {
+    stage('Prepare Workspace') {
+        steps {
+            // Clean before build
+            cleanWs()
+            // We need to explicitly checkout from SCM here
+            checkout scm
+            echo "Building ${env.JOB_NAME}..."
+        }
+    }    
       stage('Create AWS instance for AWS AMI') {
           steps {
               script {

--- a/JenkinsfileGenericCloud
+++ b/JenkinsfileGenericCloud
@@ -53,7 +53,20 @@ pipeline {
       ALMA_REPO_IP = credentials('alma_repo_ip')
   }
 
+  options {
+    // This is required if you want to clean before build
+    skipDefaultCheckout(true)
+  }
   stages {
+    stage('Prepare Workspace') {
+        steps {
+            // Clean before build
+            cleanWs()
+            // We need to explicitly checkout from SCM here
+            checkout scm
+            echo "Building ${env.JOB_NAME}..."
+        }
+    } 
       stage('Create build environment') {
           steps {
               script {

--- a/JenkinsfileGenericCloud
+++ b/JenkinsfileGenericCloud
@@ -51,6 +51,7 @@ pipeline {
       EQUINIX_IP = credentials('equinix_ip')
       KOJI_IP = credentials('koji_ip')
       ALMA_REPO_IP = credentials('alma_repo_ip')
+      OS_MAJOR_VER = "${params.OS_MAJOR_VER}"
   }
 
   options {
@@ -70,7 +71,6 @@ pipeline {
       stage('Create build environment') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -87,7 +87,6 @@ pipeline {
       stage('Build Generic Cloud Images') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -104,7 +103,6 @@ pipeline {
       stage('Test Generic Cloud images') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -129,7 +127,6 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
-                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Release to public ?', ok: 'Starting releasing!',
@@ -161,7 +158,6 @@ pipeline {
           }
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VERv
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                     if (arch == 'x86_64') {
@@ -192,7 +188,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {

--- a/JenkinsfileGenericCloud
+++ b/JenkinsfileGenericCloud
@@ -119,7 +119,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-dev-testing-bala',
+                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -182,12 +182,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -207,7 +207,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileGenericCloud
+++ b/JenkinsfileGenericCloud
@@ -32,6 +32,7 @@ def performReleaseStages(String hypervisor, String arch) {
 pipeline {
   agent any
   parameters {
+      choice(name: 'OS_MAJOR_VER', choices: ['8', '9'], description: 'AlmaLinux Major Version')
       choice(name: 'IMAGE', choices: ['GenericCloud', 'AWS AMI', 'Vagrant Box', 'OpenNebula'], description: 'Cloud image to update: build, test, release')
       extendedChoice(defaultValue: 'x86_64', description: 'Architecture to build', descriptionPropertyValue: '', multiSelectDelimiter: ',', name: 'ARCH', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_MULTI_SELECT', value: 'x86_64, aarch64', visibleItemCount: 2)
       string(name: 'BUCKET', defaultValue: 'alcib', description: 'S3 BUCKET NAME')
@@ -56,6 +57,7 @@ pipeline {
       stage('Create build environment') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -72,6 +74,7 @@ pipeline {
       stage('Build Generic Cloud Images') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -88,6 +91,7 @@ pipeline {
       stage('Test Generic Cloud images') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -102,7 +106,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#test-auto-vagrant',
+                  slackSend channel: '#albs-dev-testing-bala',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -112,6 +116,7 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
+                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Release to public ?', ok: 'Starting releasing!',
@@ -143,6 +148,7 @@ pipeline {
           }
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VERv
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                     if (arch == 'x86_64') {
@@ -163,16 +169,17 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -187,7 +194,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileGenericCloud
+++ b/JenkinsfileGenericCloud
@@ -117,7 +117,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
+                  slackSend channel: '#albs-jenkins-action-required',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -178,12 +178,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -202,7 +202,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileOpenNebula
+++ b/JenkinsfileOpenNebula
@@ -32,6 +32,7 @@ def performReleaseStages(String hypervisor, String arch) {
 pipeline {
   agent any
   parameters {
+      choice(name: 'OS_MAJOR_VER', choices: ['8', '9'], description: 'AlmaLinux Major Version')
       choice(name: 'IMAGE', choices: ['OpenNebula', 'GenericCloud', 'AWS AMI', 'Vagrant Box'], description: 'Cloud image to update: build, test, release')
       extendedChoice(defaultValue: 'x86_64', description: 'Architecture to build', descriptionPropertyValue: '', multiSelectDelimiter: ',', name: 'ARCH', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_MULTI_SELECT', value: 'x86_64, aarch64', visibleItemCount: 2)
       string(name: 'BUCKET', defaultValue: 'alcib', description: 'S3 BUCKET NAME')
@@ -57,6 +58,7 @@ pipeline {
       stage('Create build environment') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -73,6 +75,7 @@ pipeline {
       stage('Build OpenNebula Image') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -89,6 +92,7 @@ pipeline {
       stage('Test OpenNebula images') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -103,7 +107,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#test-auto-vagrant',
+                  slackSend channel: '#albs-dev-testing-bala',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -113,6 +117,7 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
+                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Release to public ?', ok: 'Starting releasing!',
@@ -144,6 +149,7 @@ pipeline {
           }
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                     if (arch == 'x86_64') {
@@ -164,16 +170,17 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -188,11 +195,12 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {

--- a/JenkinsfileOpenNebula
+++ b/JenkinsfileOpenNebula
@@ -120,7 +120,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-dev-testing-bala',
+                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -183,12 +183,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -208,7 +208,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileOpenNebula
+++ b/JenkinsfileOpenNebula
@@ -118,7 +118,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
+                  slackSend channel: '#albs-jenkins-notifications',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to be released , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -179,12 +179,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -203,7 +203,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileOpenNebula
+++ b/JenkinsfileOpenNebula
@@ -52,6 +52,7 @@ pipeline {
       KOJI_IP = credentials('koji_ip')
       ALMA_REPO_IP = credentials('alma_repo_ip')
       SIGN_JWT_TOKEN = credentials('sign_jwt_token')
+      OS_MAJOR_VER = "${params.OS_MAJOR_VER}"
   }
 
   options {
@@ -71,7 +72,6 @@ pipeline {
       stage('Create build environment') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -88,7 +88,6 @@ pipeline {
       stage('Build OpenNebula Image') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -105,7 +104,6 @@ pipeline {
       stage('Test OpenNebula images') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -130,11 +128,10 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
-                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Release to public ?', ok: 'Starting releasing!',
-                        parameters: [choice(name: 'RELEASE_SCOPE', choices: 'yes\nno')]
+                        parameters: [choice(name: 'RELEASE_SCOPE', choices: 'no\nyes')]
                       )
                       env.RELEASE_SCOPE = userInput
                       if (env.RELEASE_SCOPE == 'yes') {
@@ -162,7 +159,6 @@ pipeline {
           }
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                     if (arch == 'x86_64') {
@@ -193,7 +189,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {
@@ -213,7 +208,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (arch in params.ARCH.replace('"', '').split(',')) {
                       if (arch == 'x86_64') {

--- a/JenkinsfileOpenNebula
+++ b/JenkinsfileOpenNebula
@@ -54,7 +54,20 @@ pipeline {
       SIGN_JWT_TOKEN = credentials('sign_jwt_token')
   }
 
+  options {
+    // This is required if you want to clean before build
+    skipDefaultCheckout(true)
+  }
   stages {
+    stage('Prepare Workspace') {
+        steps {
+            // Clean before build
+            cleanWs()
+            // We need to explicitly checkout from SCM here
+            checkout scm
+            echo "Building ${env.JOB_NAME}..."
+        }
+    } 
       stage('Create build environment') {
           steps {
               script {

--- a/JenkinsfileVagrant
+++ b/JenkinsfileVagrant
@@ -95,7 +95,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
+                  slackSend channel: '#albs-jenkins-action-required',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to Vagrant Cloud , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -152,12 +152,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-notifications',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -171,7 +171,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-jenkins-notifications-dev-qa',
+          slackSend channel: '#albs-jenkins-action-required',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/JenkinsfileVagrant
+++ b/JenkinsfileVagrant
@@ -44,6 +44,7 @@ pipeline {
       VAGRANT_CLOUD_ACCESS_KEY = credentials('jenkins-vagrant-user-access-key')
       SSH_KEY_FILE = credentials('jenkins-aclib-ssh-private-key')
       WINDOWS_CREDS = credentials('jenkins-windows-creds')
+      OS_MAJOR_VER = "${params.OS_MAJOR_VER}"
   }
 
   options {
@@ -63,7 +64,6 @@ pipeline {
       stage('Create AWS instance for Vagrant') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performCreateStages(hv)
@@ -75,7 +75,6 @@ pipeline {
       stage('Build Vagrant Box') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performBuildStages(hv)
@@ -87,7 +86,6 @@ pipeline {
       stage('Test Vagrant Box') {
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performTestStages(hv)
@@ -107,7 +105,6 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
-                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Upload to Vagrant Cloud', ok: 'Starting uploading!',
@@ -140,7 +137,6 @@ pipeline {
           }
           steps {
               script {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)
@@ -166,7 +162,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)
@@ -181,7 +176,6 @@ pipeline {
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
-                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)

--- a/JenkinsfileVagrant
+++ b/JenkinsfileVagrant
@@ -46,7 +46,20 @@ pipeline {
       WINDOWS_CREDS = credentials('jenkins-windows-creds')
   }
 
+  options {
+    // This is required if you want to clean before build
+    skipDefaultCheckout(true)
+  }
   stages {
+    stage('Prepare Workspace') {
+        steps {
+            // Clean before build
+            cleanWs()
+            // We need to explicitly checkout from SCM here
+            checkout scm
+            echo "Building ${env.JOB_NAME}..."
+        }
+    } 
       stage('Create AWS instance for Vagrant') {
           steps {
               script {

--- a/JenkinsfileVagrant
+++ b/JenkinsfileVagrant
@@ -31,6 +31,7 @@ def performDestroyStages(String hypervisor) {
 pipeline {
   agent any
   parameters {
+      choice(name: 'OS_MAJOR_VER', choices: ['8', '9'], description: 'AlmaLinux Major Version')
       choice(name: 'IMAGE', choices: ['Vagrant Box', 'AWS AMI', 'GenericCloud', 'OpenNebula'], description: 'Cloud image to update: build, test, release')
       extendedChoice(defaultValue: 'VirtualBox', description: 'Hypervisors options to  build Vagrant Box', descriptionPropertyValue: '', multiSelectDelimiter: ',', name: 'HYPERVISORS', quoteValue: false, saveJSONParameterToFile: false, type: 'PT_MULTI_SELECT', value: 'VirtualBox, VMWare_Desktop, KVM, HyperV', visibleItemCount: 4)
       string(name: 'BUCKET', defaultValue: 'alcib', description: 'S3 BUCKET NAME')
@@ -49,6 +50,7 @@ pipeline {
       stage('Create AWS instance for Vagrant') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performCreateStages(hv)
@@ -60,6 +62,7 @@ pipeline {
       stage('Build Vagrant Box') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performBuildStages(hv)
@@ -71,6 +74,7 @@ pipeline {
       stage('Test Vagrant Box') {
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performTestStages(hv)
@@ -80,7 +84,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#test-auto-vagrant',
+                  slackSend channel: '#albs-dev-testing-bala',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to Vagrant Cloud , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -90,6 +94,7 @@ pipeline {
           steps {
               timeout(time:1, unit:'DAYS') {
                   script {
+                      env.OS_MAJOR_VER = params.OS_MAJOR_VER
                       def userInput = input(
                         id: 'userInput',
                         message: 'Upload to Vagrant Cloud', ok: 'Starting uploading!',
@@ -122,6 +127,7 @@ pipeline {
           }
           steps {
               script {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)
@@ -137,16 +143,17 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)
@@ -156,11 +163,12 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#test-auto-vagrant',
+          slackSend channel: '#albs-dev-testing-bala',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {
               if (params.DESTROY == true) {
+                  env.OS_MAJOR_VER = params.OS_MAJOR_VER
                   def jobs = [:]
                   for (hv in params.HYPERVISORS.replace('"', '').split(',')) {
                       jobs[hv] = performDestroyStages(hv)

--- a/JenkinsfileVagrant
+++ b/JenkinsfileVagrant
@@ -97,7 +97,7 @@ pipeline {
           }
           post {
               success {
-                  slackSend channel: '#albs-dev-testing-bala',
+                  slackSend channel: '#albs-jenkins-notifications-dev-qa',
                             color: 'good',
                             message: "The build ${currentBuild.fullDisplayName} ready to be uploaded to Vagrant Cloud , please, approve: ${currentBuild.absoluteUrl}"
               }
@@ -156,12 +156,12 @@ pipeline {
           archiveArtifacts artifacts: '*.log'
       }
       success {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'good',
                     message: "The build ${currentBuild.fullDisplayName} completed successfully : ${currentBuild.absoluteUrl}"
       }
       failure {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'danger',
                     message: "The build ${currentBuild.fullDisplayName} failed : ${currentBuild.absoluteUrl}"
           script {
@@ -176,7 +176,7 @@ pipeline {
           }
       }
       aborted {
-          slackSend channel: '#albs-dev-testing-bala',
+          slackSend channel: '#albs-jenkins-notifications-dev-qa',
                     color: 'warning',
                     message: "The build ${currentBuild.fullDisplayName} was aborted : ${currentBuild.absoluteUrl}"
           script {

--- a/ansible/configure_aws_instance.yml
+++ b/ansible/configure_aws_instance.yml
@@ -3,7 +3,7 @@
 - name: configure aws instance
   hosts: all
   remote_user: root
-  gather_facts: no
+  gather_facts: yes
 
   roles: 
     - aws_instance

--- a/ansible/roles/aws_amd64/tasks/main.yml
+++ b/ansible/roles/aws_amd64/tasks/main.yml
@@ -1,9 +1,0 @@
----
-- name: Install UEFI OVMF files
-  yum:
-    name: https://www.kraxel.org/repos/jenkins/edk2/edk2.git-ovmf-x64-0-20220719.209.gf0064ac3af.EOL.no.nore.updates.noarch.rpm
-    state: present
-  become_user: root
-  become: true
-  when:
-    - (ansible_distribution_major_version|int == 8 and ansible_architecture in ['x86_64'])

--- a/ansible/roles/aws_amd64/tasks/main.yml
+++ b/ansible/roles/aws_amd64/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install UEFI OVMF files
+  yum:
+    name: https://www.kraxel.org/repos/jenkins/edk2/edk2.git-ovmf-x64-0-20220719.209.gf0064ac3af.EOL.no.nore.updates.noarch.rpm
+    state: present
+  become_user: root
+  become: true
+  when:
+    - (ansible_distribution_major_version|int == 8 and ansible_architecture in ['x86_64'])

--- a/ansible/roles/aws_instance/tasks/main.yml
+++ b/ansible/roles/aws_instance/tasks/main.yml
@@ -47,14 +47,14 @@
     # version: master
     force: yes
 
-- name: Clone Docker images repo
-  become_user: root
-  become: true
-  git:
-    repo: 'https://github.com/VanessaRish/docker-images.git'
-    dest: './docker-images'
-    # version: master
-    force: yes
+# - name: Clone Docker images repo
+#   become_user: root
+#   become: true
+#   git:
+#     repo: 'https://github.com/AlmaLinux/docker-images.git'
+#     dest: './docker-images'
+#     # version: master
+#     force: yes
 
 - name: Change permissions
   file:
@@ -65,14 +65,14 @@
     owner: ec2-user
   become: yes
 
-- name: Change permissions
-  file:
-    path: './docker-images'
-    mode: 0777
-    recurse: yes
-    group: ec2-user
-    owner: ec2-user
-  become: yes
+# - name: Change permissions
+#   file:
+#     path: './docker-images'
+#     mode: 0777
+#     recurse: yes
+#     group: ec2-user
+#     owner: ec2-user
+#   become: yes
 
 #- name: Disable SELinux
 #  shell: setenforce 0

--- a/ansible/roles/aws_instance/tasks/main.yml
+++ b/ansible/roles/aws_instance/tasks/main.yml
@@ -14,16 +14,28 @@
     - anaconda-tui
     - subscription-manager
 
-- name: Install Python development tools
+- name: Install Python development tools 8
   ansible.builtin.dnf:
     name:
       - python39-devel
-      - python39-wheel-wheel
+      - python39-wheel-wheel      
       - python39-wheel
       - python39-setuptools-wheel
       - python39-setuptools
-  become: yes
+  become: true
   become_user: root
+  when: ansible_distribution_major_version == '8'
+
+- name: Install Python development tools 9
+  ansible.builtin.dnf:
+    name:
+      - python3-devel
+      - python3-pip-wheel
+      - python3-setuptools-wheel
+      - python3-setuptools
+  become: true
+  become_user: root
+  when: ansible_distribution_major_version == '9'
 
 - name: Installing testinfra
   pip:
@@ -35,7 +47,7 @@
     executable: pip3.9
     extra_args: --no-cache-dir --upgrade
     state: present
-  become: yes
+  become: true
   become_user: root
 
 - name: Clone cloud-images repo

--- a/ansible/roles/aws_instance/tasks/main.yml
+++ b/ansible/roles/aws_instance/tasks/main.yml
@@ -65,6 +65,26 @@
     owner: ec2-user
   become: yes
 
+- name: Add UEFI OVMF repo
+  ansible.builtin.yum_repository:
+    name: firmware
+    description: kraxel firmware repo
+    baseurl: https://www.kraxel.org/repos/jenkins/
+    gpgcheck: no
+  become_user: root
+  become: true
+  when: ansible_architecture == 'x86_64'
+
+- name: Install UEFI OVMF files
+  ansible.builtin.yum:
+    name:
+      - edk2.git-ovmf-x64
+#    name: https://www.kraxel.org/repos/jenkins/edk2/edk2.git-ovmf-x64-0-20220719.209.gf0064ac3af.EOL.no.nore.updates.noarch.rpm
+    disable_gpg_check: yes
+  become_user: root
+  become: true
+  when: ansible_architecture == 'x86_64'
+ 
 # - name: Change permissions
 #   file:
 #     path: './docker-images'

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -25,7 +25,7 @@
   become_user: root
   become: true
   git:
-    repo: 'https://github.com/VanessaRish/docker-images.git'
+    repo: 'https://github.com/AlmaLinux/docker-images.git'
     dest: './docker-images'
     # version: master
     force: yes

--- a/ansible/roles/install_packer/tasks/main.yml
+++ b/ansible/roles/install_packer/tasks/main.yml
@@ -44,8 +44,8 @@
   become: true
   vars:
     packages:
-    - git
-    - python3-devel
+    - git-core
+    - python39-devel
     - jq
     - lorax
     - anaconda-tui
@@ -57,21 +57,21 @@
     executable: pip3
   become: yes
   become_user: root
+#
+# - name: Clone Docker images repo
+#   become_user: alcib
+#   become: true
+#   git:
+#     repo: 'https://github.com/AlmaLinux/docker-images.git'
+#     dest: './docker-images'
+#     # version: master
+#     force: yes
 
-- name: Clone Docker images repo
-  become_user: alcib
-  become: true
-  git:
-    repo: 'https://github.com/VanessaRish/docker-images.git'
-    dest: './docker-images'
-    # version: master
-    force: yes
-
-- name: Change permissions
-  file:
-    path: './docker-images'
-    mode: 0777
-    recurse: yes
-    group: alcib
-    owner: alcib
-  become: yes
+# - name: Change permissions
+#   file:
+#     path: './docker-images'
+#     mode: 0777
+#     recurse: yes
+#     group: alcib
+#     owner: alcib
+#   become: yes

--- a/lib/hypervisors.py
+++ b/lib/hypervisors.py
@@ -330,7 +330,10 @@ class BaseHypervisor:
             cmd = self.packer_build_gencloud.format(self.os_major_ver, build_log)
             cmd2 = self.packer_build_gencloud2.format(self.os_major_ver, build_log_2)
         elif settings.image == 'OpenNebula':
-            cmd = self.packer_build_opennebula.format(self.os_major_ver, build_log)
+            if self.os_major_ver == '8':
+                cmd = self.packer_build_opennebula.format(self.os_major_ver, build_log)
+            else:
+                cmd = self.packer_build_opennebula2.format(self.os_major_ver, build_log)            
         else:
             cmd = self.packer_build_cmd.format(self.os_major_ver, build_log)
         try:
@@ -868,14 +871,12 @@ class KVM(LinuxHypervisors):
     )
 
     packer_build_opennebula = (
-        "cd cloud-images && PACKER_LOG=1 && "
+        "cd cloud-images && "
         "packer build -var qemu_binary='/usr/libexec/qemu-kvm' "
-        "-var firmware_x86_64='/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd' "
         "-only=qemu.almalinux-{}-opennebula-x86_64 . 2>&1 | tee ./{}"
     )
-
     packer_build_opennebula2 = (
-        "cd cloud-images && PACKER_LOG=1 && "
+        "cd cloud-images && "
         "packer build -var qemu_binary='/usr/libexec/qemu-kvm' "
         "-var firmware_x86_64='/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd' "
         "-only=qemu.almalinux-{}-opennebula-x86_64 . 2>&1 | tee ./{}"
@@ -1220,11 +1221,7 @@ class Equinix(BaseHypervisor):
         if settings.image == 'GenericCloud':
             cmd = self.packer_build_gencloud.format(self.os_major_ver, gc_build_log)
         else:
-            if self.os_major_ver == '8':
-                cmd = self.packer_build_opennebula.format(self.os_major_ver, gc_build_log)
-            else:
-                cmd = self.packer_build_opennebula2.format(self.os_major_ver, gc_build_log)
-            logging.info('%s, opennebula_cmd', cmd)
+            cmd = self.packer_build_opennebula.format(self.os_major_ver, gc_build_log)
         try:
             stdout, _ = ssh.safe_execute(cmd)
         finally:

--- a/lib/hypervisors.py
+++ b/lib/hypervisors.py
@@ -868,14 +868,14 @@ class KVM(LinuxHypervisors):
     )
 
     packer_build_opennebula = (
-        "cd cloud-images && "
+        "cd cloud-images && PACKER_LOG=1 && "
         "packer build -var qemu_binary='/usr/libexec/qemu-kvm' "
         "-var firmware_x86_64='/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd' "
         "-only=qemu.almalinux-{}-opennebula-x86_64 . 2>&1 | tee ./{}"
     )
 
     packer_build_opennebula2 = (
-        "cd cloud-images && "
+        "cd cloud-images && PACKER_LOG=1 && "
         "packer build -var qemu_binary='/usr/libexec/qemu-kvm' "
         "-var firmware_x86_64='/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd' "
         "-only=qemu.almalinux-{}-opennebula-x86_64 . 2>&1 | tee ./{}"

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def almalinux_wiki_pr():
     """
     Executes Github API calls for making commit and pull request.
     """
-    repo = 'https://api.github.com/repos/VanessaRish/wiki'
+    repo = 'https://api.github.com/repos/AlmaLinux/wiki'
     response = requests.post(
         f'{repo}/merge-upstream',
         headers=headers, data='{"branch":"master"}'
@@ -107,7 +107,7 @@ def almalinux_wiki_pr():
 
 
 def create_new_branch():
-    repo = 'https://api.github.com/repos/VanessaRish/docker-images'
+    repo = 'https://api.github.com/repos/AlmaLinux/docker-images'
     branches = get_git_branches(headers, repo)
     branch = branches[-1]
     if f'al-{settings.almalinux}-{TIMESTAMP}' not in branches:


### PR DESCRIPTION
Changes to add Jenkins Cloud image builds for AlmaLinux 9.

- Added a new parameter to accept AlmaLinux major version
- export major version to an environment variable to use in scripts
- Added pre-cleanup workspace step; without it jobs reports logs from prior runs on the same day 
- better log names
- channel name update
- ansible updates and cleanup
