### PR TITLE
Rollback VirtualBox from 7.0.2 to 6.1.40

### DIFF
--- a/terraform/virtualbox/main.tf
+++ b/terraform/virtualbox/main.tf
@@ -15,7 +15,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "ALCIB-VirtualBox" {
-  ami = "ami-09c76671ac21577dc"
+  ami = "ami-0d07edc17e80b4239"
   instance_type               = "i3.metal"
   associate_public_ip_address = "true"
   key_name                    = "alcib-user-prod"


### PR DESCRIPTION
The build with packer borken with VirtualBox 7.0.2. Use the Latest version of 6.0 for now

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>